### PR TITLE
Add support for SLE 15.1 / Leap 15.1

### DIFF
--- a/helpers/ib/00-cleanup
+++ b/helpers/ib/00-cleanup
@@ -29,7 +29,7 @@ get_package_list()
 	PACKAGE_LIST+=" nvme-cli nvmetcli bc"
 
 	case $(get_suse_version $host) in
-		15)
+		15|15.1)
 			PACKAGE_LIST+=" python3-targetcli-fb "
 			PACKAGE_LIST+=" mpitests-openmpi2 mpitests-mpich"
 		;;

--- a/ib-test.sh
+++ b/ib-test.sh
@@ -293,7 +293,7 @@ run_phase 7 phase_7 "RDMA/Verbs"
 #########################
 phase_8(){
 	case $(get_suse_version $HOST1) in
-		15)
+		15|15.1)
 			juLog -name=mpitests_skipping_openmpi 'echo "WARNING: Disabling OpenMPI for SLE15"'
 			MPI_FLAVOURS=$(echo $MPI_FLAVOURS | sed -e 's/openmpi,//g' -e 's/openmpi$//g')
 			;;


### PR DESCRIPTION
For SLE 15 SP1 and Leap 15.1 we need to expand the version check to
match both, 15 and 15.1.

Signed-off-by: Michael Moese <mmoese@suse.de>