### PR TITLE
Make sure the test does not die when target already present

### DIFF
--- a/helpers/ib/04-srp
+++ b/helpers/ib/04-srp
@@ -46,7 +46,7 @@ test_srp()
 					mount -o loop /tmp/hpc-test.io /tmp/hpc-test.mount &&
 					dd if=/dev/urandom bs=1M count=64 of=/tmp/hpc-test.mount/input &&
 					umount /tmp/hpc-test.mount"
-	tp $client 'umount /tmp/srp-hpc-test || true;
+	tp $client '(umount /tmp/srp-hpc-test; rmmod ib_srp) || true;
 	   		    rm -Rf /tmp/srp-hpc-test || true;
 				modprobe ib_srp &&
 				mkdir /tmp/srp-hpc-test &&
@@ -59,8 +59,7 @@ test_srp()
 				cp -R /tmp/srp-hpc-test/input /tmp/srp-hpc-test/output &&
 				diff -q /tmp/srp-hpc-test/input /tmp/srp-hpc-test/output&&
 				umount /tmp/srp-hpc-test &&
-				rmmod ib_srp
-	 '
+				rmmod ib_srp'
 	tp $srp_server "mount -o loop /tmp/hpc-test.io /tmp/hpc-test.mount &&
 					diff -q /tmp/hpc-test.mount/input /tmp/hpc-test.mount/output &&
 					umount /tmp/hpc-test.mount"


### PR DESCRIPTION
Writing to /sys/class/infiniband_srp/srp-<foo>/add_target with the target
already being present, the test should not just fail. In this case, we
should just continue the test execution.

Signed-off-by: Michael Moese <mmoese@suse.de>