### PR TITLE
Add a delay after starting the opensm

### DIFF
--- a/ib-test.sh
+++ b/ib-test.sh
@@ -169,7 +169,7 @@ phase_1_1(){
 	if [ $DO_MAD -eq 1 ]; then
 		juLog_fatal -name=h1_openSM_start "start_opensm $HOST1 -p 10"
 		# Leave some time for openSM to bring the link up
-		sleep 10
+		sleep 30
 	fi
 }
 run_phase 1 phase_1_1 "Fabric init (1/2)"


### PR DESCRIPTION
When we start the opensm again after killing it, we need to wait a
little bit for the subnet manager to come up and configure the links,
otherwise the following tests may fail.
Let's wait a while until we continue in this case, so the following
testcase will not fail randomly.

Signed-off-by: Michael Moese <mmoese@suse.de>