### PR TITLE
Sort the output of ibstat -l

### DIFF
--- a/helpers/ib/01-fabric-init
+++ b/helpers/ib/01-fabric-init
@@ -41,7 +41,7 @@ get_port()
 	local host=$1
 	local host_id=$2
 
-	res=$(tpq $host '(boards=$(/usr/sbin/ibstat -l);
+	res=$(tpq $host '(boards=$(/usr/sbin/ibstat -l | sort);
 ip_count=0;
 for board in $boards; do
 	port_count=$(/usr/sbin/ibstat $board -p | wc -l);


### PR DESCRIPTION
On one of my machines, ibstat returns the second port of a card before
the first one. Those machines are connected back to back, without any
switch, and actually only the first port is to be used.
When not sorting the ports, the ib_ipoib configuration is done in a way,
that will use the wrong interface and thus end up using routes that will
never reach anything.