### PR TITLE
Use natural sort of numbers in text

### DIFF
--- a/helpers/ib/01-fabric-init
+++ b/helpers/ib/01-fabric-init
@@ -41,7 +41,7 @@ get_port()
 	local host=$1
 	local host_id=$2
 
-	res=$(tpq $host '(boards=$(/usr/sbin/ibstat -l | sort);
+	res=$(tpq $host '(boards=$(/usr/sbin/ibstat -l | sort -V);
 ip_count=0;
 for board in $boards; do
 	port_count=$(/usr/sbin/ibstat $board -p | wc -l);


### PR DESCRIPTION
As remarked when added the sort, we should use a way to sort the names
when theres not only mlx_0 and mlx_1 but also say mlx_10. GNU sort can
do that for us with the option -V.