### PR TITLE
Ignore some errors in order to allow successful execution

### DIFF
--- a/helpers/ib/00-cleanup
+++ b/helpers/ib/00-cleanup
@@ -38,6 +38,6 @@ reset_all_ports()
 	local host=$1
 
 	tp $host 'for port_guid in $(ibstat -p); do
-	   		 	   ibportstate -G $port_guid reset;
+	   		 	   ibportstate -G $port_guid reset || true;
 			   done'
 }

--- a/helpers/ib/04-srp
+++ b/helpers/ib/04-srp
@@ -51,7 +51,7 @@ test_srp()
 				modprobe ib_srp &&
 				mkdir /tmp/srp-hpc-test &&
 				(ibsrpdm -c | grep "dgid='$server_wwn'";
-				 ibsrpdm -c | grep "dgid='$server_sys_wwn'" | sed -e "s/'$server_sysguid'/'$server_guid'/g") > /sys/class/infiniband_srp/srp-'$client_board'-'$client_port'/add_target &&
+				 ibsrpdm -c | grep "dgid='$server_sys_wwn'" | sed -e "s/'$server_sysguid'/'$server_guid'/g" | true) > /sys/class/infiniband_srp/srp-'$client_board'-'$client_port'/add_target &&
 				sleep 1 &&
 				block_device=$(ls /sys/class/infiniband/'$client_board'/device/host*/target*/*:*/block) &&
 				mount /dev/$block_device /tmp/srp-hpc-test &&


### PR DESCRIPTION
Two minor fixes allowing the tests to be executed properly:

1. Don't fail the run if we cannot reset all ports. We can ignore this.
2. Ignore an error from sed and allow the SRP test to execute