### PR TITLE
Add missing 15.4 to get required package list for installing

### DIFF
--- a/helpers/common/00-cleanup
+++ b/helpers/common/00-cleanup
@@ -65,7 +65,7 @@ get_common_package_list()
 			PACKAGE_LIST+=" python3-targetcli-fb "
 			PACKAGE_LIST+=" mpitests-openmpi2 mpitests-mpich"
 			;;
-		15.2|15.3)
+		15.2|15.3|15.4)
 			PACKAGE_LIST+=" python3-targetcli-fb "
 			PACKAGE_LIST+=" mpitests-openmpi2 mpitests-mpich"
 			PACKAGE_LIST+=" mpitests-openmpi3"


### PR DESCRIPTION
The `get_common_package_list` is missing developing product 15.4.
The packages are checked for availability in 15.4 and looks ok.

Signed-off-by: ybonatakis <ybonatakis@suse.com>