### PR TITLE
helpers/common: Add -x/--exclude flag

### DIFF
--- a/helpers/common.sh
+++ b/helpers/common.sh
@@ -205,6 +205,7 @@ export END_PHASE=${END_PHASE:-$DEFAULT_END_PHASE}
 export IN_VM=0
 export HOST1=
 export HOST2=
+export EXCLUDE_TESTS=
 
 common_usage(){
     echo "  -h, --help                     Display usage"
@@ -215,6 +216,7 @@ common_usage(){
     echo "      --in-vm                    Test is being run in a virtual machine"
     echo "  -S, --suite <name>             Set JUnit testsuite name"
     echo "  -M, --mpi <mpi>[,<mpi>...]     Comma separated list of MPI flavours to test"
+    echo "  -x, --exclude <name>[,<name>...]  Comma separated list of test names to skip"
 
 }
 
@@ -247,6 +249,10 @@ common_parse(){
             ;;
 	-M|--mpi)
 	    MPI_FLAVOURS=$2
+	    return 2
+	    ;;
+	-x|--exclude)
+	    EXCLUDE_TESTS=$2
 	    return 2
 	    ;;
 	--help|-h)


### PR DESCRIPTION
Only a proposal/question: add `--exclude`, so in case of some problems, any test could be excluded.

**Why**: we use some scripts `known_issue` and if we could exclude from runs, we could avoid `post-processing` of the results which is typically ugly.

If you are OK with the idea, I would take a look if I could get this done.